### PR TITLE
clog: a more detailed circular C scale

### DIFF
--- a/src/SlideRules/Renderer/Diagrams.hs
+++ b/src/SlideRules/Renderer/Diagrams.hs
@@ -59,7 +59,7 @@ tickToDiagram renderSettings@RenderSettings{ heightMultiplier, textMultiplier } 
 tickToDiagramStatic :: RenderSettings -> Tick -> D.Diagram D.B
 tickToDiagramStatic RenderSettings{ heightMultiplier, textMultiplier } tick =
     let Tick { _prePos, _postPos, _info } = tick
-        TickInfo { _start, _end, _mlabel } = _info
+        TickInfo { _start, _end, _mlabel, _tickColor } = _info
         startV2 = D.r2 (0, heightMultiplier * _start)
         endV2   = D.r2 (0, heightMultiplier * _end)
         diffV2  = endV2 - startV2
@@ -77,8 +77,9 @@ tickToDiagramStatic RenderSettings{ heightMultiplier, textMultiplier } tick =
                       FromBottomAbs x -> startV2 + D.r2 (0, heightMultiplier * x)
             pure $
                 D.alignedText (realToFrac $ _xPct _textAnchor) (realToFrac $ _yPct _textAnchor) _text
-                  & D.fontSizeL (realToFrac $ heightMultiplier * textMultiplier * _fontSize) & D.fc D.black
-                  & D.font "Comfortaa"
+                  & D.fontSizeL (realToFrac $ heightMultiplier * textMultiplier * _fontSize)
+                  & D.fcA _labelColor
+                  & D.font "Bitstream Charter, monospace"
                   & D.translate (fmap realToFrac labelOffset)
-     in D.lc D.red tickDia <> labelDia
+     in D.lcA _tickColor tickDia <> labelDia
 

--- a/src/SlideRules/Tick.hs
+++ b/src/SlideRules/Tick.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 module SlideRules.Tick where
 
@@ -83,10 +84,13 @@ data TickInfo = TickInfo
     { _start  :: InternalFloat
     , _end    :: InternalFloat
     , _mlabel :: Maybe Label
+    , _tickColor :: D.AlphaColour Double
     }
     deriving (Show, Generic)
 
 instance NFData TickInfo
+instance NFData c => NFData (D.AlphaColour c) where
+  rnf _c = ()
 
 instance Default TickInfo where
     def =
@@ -94,6 +98,7 @@ instance Default TickInfo where
             { _start = 0
             , _end = 1
             , _mlabel = Nothing
+            , _tickColor = D.opaque D.red
             }
 
 data Label = Label
@@ -102,6 +107,7 @@ data Label = Label
     , _textAnchor   :: TextAnchor
     , _tickAnchor   :: TickAnchor
     , _anchorOffset :: D.V2 InternalFloat
+    , _labelColor   :: D.AlphaColour Double
     }
     deriving (Show, Generic)
 
@@ -115,6 +121,7 @@ instance Default Label where
             , _textAnchor = TextAnchor { _xPct = 0, _yPct = 0 }
             , _tickAnchor = FromTopAbs 0
             , _anchorOffset = D.V2 0 0
+            , _labelColor = D.opaque D.black
             }
 
 data TextAnchor = TextAnchor


### PR DESCRIPTION
Hi, if acceptable to you I'd like to contribute back a more detailed circular C scale I coded for fun. I tried to get this as clean, minimal and documented as I could, but please request changes if you feel so.

### Build
Both clog SVG files are meant to be printed in colors on A4 paper and plasticized:
```
convert clog-0026-stator.svg -page a4 -background white -bordercolor white -border 100 clog-0026-stator.pdf
convert clog-0026-rotor.svg  -page a4 -background white -bordercolor white -border 100 clog-0026-rotor.pdf
```
The rotor is inward and should be cut around the second bigger circle
to be pinned at the center on the stator and a piece of wood or cardboard below.

### Usage
The operands should be put in scientific notation
to facilitate the handling of orders of magnitude,
then on the wheels big digits correspond to the unit,
middle digits to the decimal and small digits to the hundredth.

To multiply, align the 1 on the rotor
with the first operand outward on the stator,
then move your eyes clockwise on the rotor up to the second operand
and read the result outward on the stator.

To divide, align the divising operand on the rotor
with the divided operand on the stator,
then move your eyes counter-clockwise up to the 1 on the rotor
and read the result outward on the stator.

Beware that if the rotor's measure encompasses
the 1 on the stator you must multiply (resp. divide) by 10
on top of adding the exponents of the scientific notations of the operands.

### SVG files
Below are the generated SVG, printable to PDF in `Firefox` or `ImageMagick` but not rendered correctly in `geeqie` (which does not print the digits at the right place):

#### The rotor
![clog-0026-rotor](https://user-images.githubusercontent.com/21160136/166166372-ceb50c22-d3fb-4445-8435-1b7e81b03bd3.svg)
#### The stator
![clog-0026-stator](https://user-images.githubusercontent.com/21160136/166166376-79734b5d-3b3a-4a0a-9b59-1d60d5ba3ad9.svg)
#### The result
![IMG_20220501_142537](https://user-images.githubusercontent.com/21160136/166167927-feb32548-5192-456b-8665-e6f5e909ee92.jpg)

PS: "clog" can be thought as a pun with "clock".

### Related
- [Mathologer's Reinventing the magic log wheel: How was this missed for 400 years?](https://www.youtube.com/watch?v=ZIQQvxSXLhI)
- https://phoenixave.com/crule/